### PR TITLE
Update Ultimate Cheats - Volume 2 (UK) (Unl).gdi

### DIFF
--- a/Metadata/Additional GDI Files/Sega - Dreamcast/Ultimate Cheats - Volume 2 (UK) (Unl).gdi
+++ b/Metadata/Additional GDI Files/Sega - Dreamcast/Ultimate Cheats - Volume 2 (UK) (Unl).gdi
@@ -1,3 +1,3 @@
 2
-1 0 0 "Ultimate Cheats - Volume 2 (UK) (Unl) (Track 1).bin" 0
+1 0 0 2352 "Ultimate Cheats - Volume 2 (UK) (Unl) (Track 1).bin" 0
 2 600 4 2352 "Ultimate Cheats - Volume 2 (UK) (Unl) (Track 2).bin" 0


### PR DESCRIPTION
2352 was missing on line 2, so building a CHD was defaulting to 2048 sector size and failing. Thank you for your continued work on this!